### PR TITLE
Setup mongo instance

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,29 @@
+# This docker-compose is for development purposes, so user + passwords
+# would need to be overwritten during stage/prod builds / deployments
+
+version: '3.1'
+
+services:
+
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+    volumes:
+        - ./migrations:/docker-entrypoint-initdb.d/
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+      MONGO_INITDB_DATABASE: mylittletodo
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    links:
+      - mongo
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: example

--- a/migrations/1_init_sample_data.sh
+++ b/migrations/1_init_sample_data.sh
@@ -1,0 +1,1 @@
+mongoimport --host localhost --db mylittletodo --collection todos --type json --file /docker-entrypoint-initdb.d/init.json --jsonArray

--- a/migrations/init.json
+++ b/migrations/init.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Buy milk",
+    "done": false
+  },
+  {
+    "name": "Call Darth Vader",
+    "done": false
+  },
+  {
+    "name": "Scan Death Star security vulnerabilities",
+    "done": false
+  }
+]


### PR DESCRIPTION
Closes #2 

### Actions

- Setup docker-compose file to startup mongo instance and admin web instance
- Initial script with dummy data

### Tests

- Try `docker-compose up` and all instances are avalaible with the initial data